### PR TITLE
can: mcp25xxfd: add a clock provider for oscout

### DIFF
--- a/Documentation/devicetree/bindings/net/can/microchip,mcp25xxfd.yaml
+++ b/Documentation/devicetree/bindings/net/can/microchip,mcp25xxfd.yaml
@@ -25,6 +25,14 @@ properties:
   interrupts-extended:
     maxItems: 1
 
+  #clock-cells:
+    maxItems: 1
+    const: 0
+
+  clock-output-names:
+    description: clock output name, of the form can?_oscout.
+    maxItems: 1
+
   clocks:
     maxItems: 1
 
@@ -47,11 +55,20 @@ properties:
       Must be half or less of "clocks" frequency.
     maximum: 20000000
 
+  mcp25xxfd,clkout-divisor:
+    oneOf:
+      - const: 1
+      - const: 2
+      - const: 4
+      - const: 10
+
 required:
   - compatible
   - reg
   - interrupts-extended
   - clocks
+  - #clock-cells
+  - clock-output-names
 
 examples:
   - |
@@ -65,6 +82,8 @@ examples:
         can@0 {
             compatible = "microchip,mcp25xxfd";
             reg = <0>;
+            #clock-cells = <0>;
+            clock-output-names = "can0_oscout";
             clocks = <&can0_osc>;
             pinctrl-names = "default";
             pinctrl-0 = <&can0_pins>;
@@ -73,5 +92,6 @@ examples:
             rx-int-gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
             vdd-supply = <&reg5v0>;
             xceiver-supply = <&reg5v0>;
+            mcp25xxfd,clkout-divisor = <1>;
         };
     };

--- a/drivers/net/can/spi/mcp25xxfd/mcp25xxfd.h
+++ b/drivers/net/can/spi/mcp25xxfd/mcp25xxfd.h
@@ -18,6 +18,7 @@
 #include <linux/regmap.h>
 #include <linux/regulator/consumer.h>
 #include <linux/spi/spi.h>
+#include <linux/clk-provider.h>
 
 /* MPC25xx registers */
 
@@ -594,6 +595,11 @@ struct mcp25xxfd_priv {
 
 	struct mcp25xxfd_devtype_data devtype_data;
 	struct can_berr_counter bec;
+
+	u32 clkodiv;
+
+	/* oscout clock */
+	struct clk_hw oscout;
 };
 
 #define MCP25XXFD_IS(_model) \


### PR DESCRIPTION
The included patches create a clock provider for the mcp25xxfd driver. The oscout clock is derived from the osc clock, and can be configured with a device tree property.

This has been tested on our custom add-on board for the beaglebone black; we have a 40 MHz oscilator connected to the first mcp2518fd; it's oscout connected to the oscilator in on the second mcp2518fd, and it's oscout connected to a different chip.

The patch keeps the chip out of sleep mode when the clock has been prepared (we go into CONFIG mode instead).